### PR TITLE
Bug corrigido na tela GenerateQrCode

### DIFF
--- a/QrAguas/ViewLayer/GenerateQrCode.cs
+++ b/QrAguas/ViewLayer/GenerateQrCode.cs
@@ -1,14 +1,7 @@
 ﻿using QRCoder;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
 using System.Drawing.Printing;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace QrAguas.ViewLayer
@@ -32,7 +25,7 @@ namespace QrAguas.ViewLayer
             // Nome do produto
             txtNomeProduto.Text = NomeProduto;
 
-            if (String.IsNullOrEmpty(DataValidade.ToString()))
+            if (DataValidade.ToString() != "01/01/0001 00:00:00")
             {
                 // Valor mínimo do DateTimePicker
                 DTPValidade.MinDate = DataValidade;

--- a/QrAguas/ViewLayer/MainForm.cs
+++ b/QrAguas/ViewLayer/MainForm.cs
@@ -187,26 +187,10 @@ namespace QrAguas.View_Layer
 
                 #region Qr Code
                 case "Gerar Novo Qr Code":
-
-                    bool generateQrCodeOpen = false;
-
-                    // Início: Este bloco de código impede que sejam abertos múltiplos forms iguais
-                    foreach (Form form in Application.OpenForms)
-                    {
-                        if (form.Name == "GenerateQrCode")
-                        {
-                            generateQrCodeOpen = true;
-                            form.BringToFront();
-                            break;
-                        }
-                    }
-                    if (generateQrCodeOpen == false)
-                    {
-                        GenerateQrCode generateQrCode = new GenerateQrCode();
-                        generateQrCode.Show();
-                    }
-                    // Fim
+                    GenerateQrCode generateQrCode = new GenerateQrCode();
+                    generateQrCode.Show();
                     break;
+
                 #endregion
 
                 #region Consultas


### PR DESCRIPTION
## Correção de bug no form GenerateQRCode

Após o cadastro de produtos ser finalizado é perguntado ao usuário
se o mesmo deseja gerar o Qr Code do produto. 
Caso a resposta seja "sim", a tela para geração de Qr Code é aberta já 
com os dados do produto inserido. O bug acontecia ao transferir a data 
de validade do form RegisterProduct para o form GenerateQrCode fazendo
com que a data de validade cadastrada e data de validade a ser inserida no
Qr Code fossem divergentes.

